### PR TITLE
Use grep instead of Alfred's filtering

### DIFF
--- a/alfred-open-windows-filter.sh
+++ b/alfred-open-windows-filter.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 exec 2> >(logger -s -t $(basename $0))
 
+FILTER="$1"
+if [ -z "$FILTER" ]; then FILTER=.;fi
+
 APPLICATION=$(osascript -sh application.ascr "$focusedapp" | sed "s/Macintosh HD//" | sed "s/:/\//g" | sed "s/\/$//")
 
 echo '<?xml version="1.0"?><items>'
@@ -8,6 +11,15 @@ echo '<?xml version="1.0"?><items>'
 osascript -sh windows.ascr "$focusedapp" | tr "\r" "\n" | while read LINE; do
     if [ "$LINE" = "" ]; then
         continue
+    fi
+    if [ "$FILTER" = "" ]; then
+        continue
+    else
+        if echo $LINE | grep -sqi $FILTER; then
+          true
+        else
+          continue
+        fi
     fi
     echo "<item arg=\"${LINE}\">"
     echo "  <title>${LINE}</title>"

--- a/info.plist
+++ b/info.plist
@@ -78,7 +78,7 @@
 			<key>config</key>
 			<dict>
 				<key>alfredfiltersresults</key>
-				<true/>
+				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
 				<integer>0</integer>
 				<key>argumenttrimmode</key>
@@ -98,7 +98,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>bash alfred-open-windows-list.sh</string>
+				<string>bash alfred-open-windows-filter.sh "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
This reverts commit a975d3c048364c353d3acbda8f8bcc49ba54a373. Alfred's built-in filtering didn't work very well on Atom window titles, which contain filenames, special chars, and full paths. `grep` works great.